### PR TITLE
Allowing `Contract.allFrom` to load abastract solidity contracts

### DIFF
--- a/lib/static/upload/Contract.ts
+++ b/lib/static/upload/Contract.ts
@@ -172,7 +172,22 @@ export class Contract extends BasicUploadableEntity<LiveContractWithLogs> {
     if (other instanceof Contract === false) {
       return false;
     }
-    return this.byteCode === other.byteCode;
+    const thisFragments = this.interface.fragments;
+    const otherFragments = other.interface.fragments;
+
+    if (thisFragments.length !== otherFragments.length) {
+      return false;
+    }
+
+    let areAbisTheSame = true;
+
+    for (const thisFragment of thisFragments) {
+      if (!otherFragments.find(otherFragment => otherFragment.format() === thisFragment.format())) {
+        areAbisTheSame = false;
+        break;
+      }
+    }
+    return this.byteCode === other.byteCode && areAbisTheSame;
   }
 
   /**

--- a/lib/static/upload/Contract.ts
+++ b/lib/static/upload/Contract.ts
@@ -44,10 +44,10 @@ type NewContractOptions = {
  */
 export class Contract extends BasicUploadableEntity<LiveContractWithLogs> {
   /**
-   * Given an index or a name, this returns a specific {@link Contract} following the successfull compilation of 
+   * Given an index or a name, this returns a specific {@link Contract} following the successful compilation of 
    * either the contract code itself ({@link options.code}) or the solidity file located at the provided {@link options.path}
    * 
-   * In terms of precidence, it first checks to see if the {@link options.name} is provided and, if so, it uses that otherwise
+   * In terms of precedence, it first checks to see if the {@link options.name} is provided and, if so, it uses that otherwise
    * it looks at the {@link options.index} one and goes with that.
    * 
    * @param {Object} options - Provides a source and controls various {@see Contract} construction settings
@@ -148,10 +148,15 @@ export class Contract extends BasicUploadableEntity<LiveContractWithLogs> {
       throw new Error("Please provide a name for the Contract instance.");
     } else if(!abi) {
       throw new Error("Please provide a, valid, EthersProject-compatible, ABI definition for the Contract instance.");
-    } else if(!byteCode || /.*__\$.*\$__.*/.test(byteCode)) {
-      throw new Error("Library linking is not currently supported. Please follow issue #38 for more info.");
-    } else if(!byteCode || !/^[0-9a-f]+$/.test(byteCode)) {
-      throw new Error("Please provide the valid formatted byte-code definition for the Contract in order to instantiate it.");
+    } else if (typeof byteCode === 'string' && byteCode.length !== 0) {
+      if(/.*__\$.*\$__.*/.test(byteCode)) {
+        throw new Error("Library linking is not currently supported. Please follow issue #38 for more info.");
+      } else if(!byteCode || !/^[0-9a-f]+$/.test(byteCode)) {
+        throw new Error("Please provide the valid formatted byte-code definition for the Contract in order to instantiate it.");
+      }
+    } else {
+      // if byteCode.length === '', yet there is an ABI, this means that most likely the loaded contract is an abstract one
+      // we permit this, but are weary when trying to upload it to a LiveContract. Basically, we won't allow uploading in this scenario.
     }
 
     super(`${name}-Contract`);
@@ -186,6 +191,9 @@ export class Contract extends BasicUploadableEntity<LiveContractWithLogs> {
   }
 
   protected override async getContent() {
+    if (!this.byteCode) {
+      throw new Error("Won't upload contract to network because it's lacking the required byte-code data.");
+    }
     return this.byteCode;
   }
 

--- a/lib/static/upload/Contract.ts
+++ b/lib/static/upload/Contract.ts
@@ -151,7 +151,7 @@ export class Contract extends BasicUploadableEntity<LiveContractWithLogs> {
     } else if (typeof byteCode === 'string' && byteCode.length !== 0) {
       if(/.*__\$.*\$__.*/.test(byteCode)) {
         throw new Error("Library linking is not currently supported. Please follow issue #38 for more info.");
-      } else if(!byteCode || !/^[0-9a-f]+$/.test(byteCode)) {
+      } else if(!/^[0-9a-f]+$/.test(byteCode)) {
         throw new Error("Please provide the valid formatted byte-code definition for the Contract in order to instantiate it.");
       }
     } else {

--- a/test/general/contracts/abstract_storage.sol
+++ b/test/general/contracts/abstract_storage.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+abstract contract SimpleStorage {
+  uint public num;
+
+  function set(uint _num) public {
+    num = _num;
+  }
+
+  function get() public view returns (uint) {
+    return num;
+  }
+}

--- a/test/general/specs/Contract.spec.ts
+++ b/test/general/specs/Contract.spec.ts
@@ -26,7 +26,21 @@ describe('Contract', () => {
     }
   });
 
-  it('given neither the source code nor the source path, instantiating a Contract should not be permitted.', async () => {
+  it('equality testing suite', async () => {
+    expect(Contract.deserialize(`{"name": "A", "byteCode": "ab", "abi": []}`).equals(Contract.deserialize(`{"name": "A", "byteCode": "ab", "abi": []}`))).toBeTruthy();
+    expect(Contract.deserialize(`{"name": "A", "abi": []}`).equals(Contract.deserialize(`{"name": "A", "abi": []}`))).toBeTruthy();
+    expect(Contract.deserialize(`{"name": "A", "abi": ["function set(uint256 _num)"]}`).equals(Contract.deserialize(`{"name": "A", "abi": ["function set(uint256 _num)"]}`))).toBeTruthy();
+    expect(Contract.deserialize(`{"name": "B", "byteCode": "beef", "abi": ["function set(uint256 _num)"]}`).equals(Contract.deserialize(`{"name": "A", "byteCode": "beef", "abi": ["function set(uint256 _num)"]}`)))
+      .toBeTruthy();
+    expect(Contract.deserialize(`{"name": "B", "byteCode": "beef", "abi": ["function num() view returns (uint256)", "function set(uint256 _num)"]}`)
+      .equals(Contract.deserialize(`{"name": "A", "byteCode": "beef", "abi": ["function set(uint256 _num)", "function num() view returns (uint256)"]}`)))
+      .toBeTruthy();
+
+    expect(Contract.deserialize(`{"name": "A", "byteCode": "ab", "abi": []}`).equals(Contract.deserialize(`{"name": "A", "byteCode": "bc", "abi": []}`))).not.toBeTruthy();
+    expect(Contract.deserialize(`{"name": "A", "abi": ["function set(uint256 _num)"]}`).equals(Contract.deserialize(`{"name": "A", "abi": []}`))).not.toBeTruthy();
+  });
+
+  it('given neither the source code nor the source path, instantiating a Contract should not be permitted', async () => {
     await expect(Contract.allFrom({ })).rejects.toThrow();
     await expect(Contract.newFrom({ })).rejects.toThrow();
   });
@@ -50,7 +64,7 @@ describe('Contract', () => {
       expect(e.constructor.name).toEqual(CompileIssues.name);
       return;
     }
-    throw new Error("Instantiating a Contract works even though it should fail having warnings reported.");
+    throw new Error("Instantiating a Contract works even though it should fail having warnings reported");
   });
 
   it("given a solidity contract code which doesn't have a license, extracting all the Contracts should succede if we don't care about compiler warnings", async () => {

--- a/test/general/specs/Contract.spec.ts
+++ b/test/general/specs/Contract.spec.ts
@@ -11,14 +11,31 @@ import { read } from '../../utils';
 const HELLO_IMPORTS_BYTECODE = read({ solo: 'hello_imports' }).evm.bytecode.object;
 
 describe('Contract', () => {
+  it('given an abstract solidity contract, it should permit creating a Contract with ABI definitions present yet have no byteCode associated with it', async () => {
+    try {
+      const contract = await Contract.newFrom({
+        code: read({ contract: 'abstract_storage' }),
+        ignoreWarnings: true,
+      });
+
+      expect(contract.interface.fragments.length).toBeGreaterThan(0);
+      expect(contract.byteCode).toBeDefined();
+      expect(contract.byteCode).toHaveLength(0);
+    } catch(e) {
+      throw new Error("Should permit loading of abstract solidity contracts but it doesn't.");
+    }
+  });
+
   it('given neither the source code nor the source path, instantiating a Contract should not be permitted.', async () => {
     await expect(Contract.allFrom({ })).rejects.toThrow();
     await expect(Contract.newFrom({ })).rejects.toThrow();
   });
 
-  it('given several invalid serialized solidity contracts, deserializing them should fail', async () => {
+  it('given several serialized contracts, deserializing them should behave accordingly', async () => {
+    expect(() => Contract.deserialize(`{"name": "A", "abi": []}`)).not.toThrow();
+    expect(() => Contract.deserialize(`{"name": "A", "abi": [], "byteCode": "beef"}`)).not.toThrow();
+
     expect(() => Contract.deserialize(`{"byteCode": "ab", "abi": []}`)).toThrow();
-    expect(() => Contract.deserialize(`{"name": "A", "abi": []}`)).toThrow();
     expect(() => Contract.deserialize(`{"name": "A", "byteCode": "$ab", "abi": []}`)).toThrow();
     expect(() => Contract.deserialize(`{"name": "A", "byteCode": "ab"}`)).toThrow();
   });

--- a/test/general/specs/LiveContract.spec.ts
+++ b/test/general/specs/LiveContract.spec.ts
@@ -11,6 +11,13 @@ import { LiveContract } from "../../../lib/live/LiveContract";
 
 describe('LiveContract', () => {
 
+  it("an abstract solidity contract should not be permitted to be uploaded to the network", async () => {
+    const { session } = await ApiSession.default();
+    const bytesContract = await Contract.newFrom({ code: read({ contract: 'abstract_storage' }) });
+    
+    expect(async () => await session.upload(bytesContract)).rejects.toThrow();
+  });
+
   it("emitting an event during contract construction time should be returned following a successful upload", async () => {
     const { liveContract, logs } = await load('constructor_event');
 

--- a/test/solidity-by-example/specs/Contract.Solidity-by-Example.spec.ts
+++ b/test/solidity-by-example/specs/Contract.Solidity-by-Example.spec.ts
@@ -1,5 +1,5 @@
 import {
-    describe, expect, it,
+  describe, expect, it,
 } from '@jest/globals';
 
 import { ResourceReadOptions, read as readResource } from '../../utils';


### PR DESCRIPTION
albeit without byte-code generation & not permitted to be uploaded via `ApiSession`s