### PR TITLE
Single `bytes` return are mapped now to `Uint8Array`

### DIFF
--- a/lib/live/LiveContract.ts
+++ b/lib/live/LiveContract.ts
@@ -309,13 +309,20 @@ export class LiveContract extends BaseLiveEntityWithBalance<ContractId, Contract
 
         fResponse = fResultKeys.map(namedfDataKey => ({ [namedfDataKey]: tryMappingToHederaBytes(namedfDataKey) }))
           .reduce((p, c) => ({...p, ...c}), {});
-      } else if (fDescription.outputs.length > 1) {
-        fResponse = [...fResult];
-
-        // Map all Ethers HexString representations of bytes-type responses to their UInt8Array forms (same used by Hedera)
-        fResponse = fDescription.outputs.map((dType, id) => dType.type.startsWith('bytes') ? arrayify(fResponse[id]) : fResponse[id]);
       } else {
-        fResponse = fResult[0];
+        fResponse = [...fResult];
+  
+        // Map all Ethers HexString representations of bytes-type responses to their UInt8Array forms (same used by Hedera)
+        fResponse = fDescription.outputs.map((dType, id) =>
+          dType.type.startsWith("bytes")
+            ? arrayify(fResponse[id])
+            : fResponse[id]
+        );
+  
+        // If there is only one result returned, we unpack it and return it as it is, ditching the hosting array
+        if (fResponse.length === 1) {
+          fResponse = fResponse[0];
+        }
       }
 
       // Do various type re-mappings such as:

--- a/test/general/specs/StratoAddress.spec.ts
+++ b/test/general/specs/StratoAddress.spec.ts
@@ -34,9 +34,13 @@ describe('LiveAddress', () => {
   it("a bytes32 return value should not be interpreted as a LiveAddress", async () => {
     const liveContract = await load('keccak256');
     const hashResult = await liveContract.hash("asta banana");
+    const expectedHashResult = Buffer.from(
+      "26d381901a017b1d62fe70cbbe9ed6cf7f66db86f97a1c64f3571b777d7fe07e",
+      "hex"
+    );
 
     expect(hashResult).not.toBeInstanceOf(StratoAddress);
-    expect(hashResult).toEqual("0x26d381901a017b1d62fe70cbbe9ed6cf7f66db86f97a1c64f3571b777d7fe07e");
+    expect(expectedHashResult.compare(hashResult)).toEqual(0);
   });
 
   it("given bytes to LiveAddress constructor, it throws an error as it is not a solidity address", async () => {

--- a/test/solidity-by-example/specs/LiveContract.Solidity-by-Example.spec.ts
+++ b/test/solidity-by-example/specs/LiveContract.Solidity-by-Example.spec.ts
@@ -1,9 +1,5 @@
-import {
-  describe, 
-  expect, 
-  it,
-} from '@jest/globals';
-import { AccountId } from "@hashgraph/sdk";
+import { AccountId, Signer } from "@hashgraph/sdk";
+import { describe, expect, it } from "@jest/globals";
 import BigNumber from "bignumber.js";
 
 import { 
@@ -178,27 +174,32 @@ describe('LiveContract.Solidity-by-Example', () => {
     await expect(liveContract.ternary(10)).resolves.toEqual(new BigNumber(2));
   });
 
+  // Requires: https://github.com/hashgraph/hedera-sdk-js/issues/1084
   it.skip("doing the signature verification flow should work", async () => {
-    // TODO: activate this once secp is working on Hedera (and available through SDK ?)
-    const liveContract = await load('signature');
+    const liveContract = await load("signature");
     const { session } = await ApiSession.default();
-    const signer = session.wallet.account.id.toSolidityAddress();
-    const to = AccountId.fromString('0.0.3').toSolidityAddress();
+    const signer = session.wallet.signer as Signer;
+    const to = AccountId.fromString("0.0.3").toSolidityAddress();
     const amount = 123;
     const message = "coffee and donuts";
     const nonce = 1;
     const messageHash = await liveContract.getMessageHash(to, amount, message, nonce);
 
-    /* TODO: uncoment this and adjust
-    const signedMessageHash = web3.personal.sign(messageHash, web3.eth.defaultAccount, console.log) ??? -- see solidity-by-example > signature.sol comments
-    const isSameSigner = await liveContract.verify(signer, to, amount, message, nonce, signedMessageHash);
+    const [{ signature: signedMessageHash }] = await signer.sign(messageHash); //??? -- see solidity-by-example > signature.sol comments
+    const isSameSigner = await liveContract.verify(
+      signer.getAccountId().toSolidityAddress(),
+      to,
+      amount,
+      message,
+      nonce,
+      signedMessageHash
+    );
 
     expect(isSameSigner).toBeTruthy();
-    */
   });
 
   // Requires: https://github.com/buidler-labs/hedera-strato-js/issues/38
-  it.skip("uploading a public library-dependent contract should succede", async () => {
+  it.skip("uploading a public library-dependent contract should succeed", async () => {
     const { session } = await ApiSession.default();
     const testArrayContract = await Contract.newFrom({ code: read({ contract: 'library' }), name: 'TestArray' });
 


### PR DESCRIPTION
... instead of hex-encoded strings.

This PR fixes that