### PR TITLE
Single `bytes` returns should maintain their `Uint8Array` type 

### DIFF
--- a/lib/live/LiveContract.ts
+++ b/lib/live/LiveContract.ts
@@ -397,7 +397,7 @@ export class LiveContract extends BaseLiveEntityWithBalance<
             [namedfDataKey]: tryMappingToHederaBytes(namedfDataKey),
           }))
           .reduce((p, c) => ({ ...p, ...c }), {});
-      } else if (fDescription.outputs.length > 1) {
+      } else {
         fResponse = [...fResult];
 
         // Map all Ethers HexString representations of bytes-type responses to their UInt8Array forms (same used by Hedera)
@@ -406,8 +406,11 @@ export class LiveContract extends BaseLiveEntityWithBalance<
             ? arrayify(fResponse[id])
             : fResponse[id]
         );
-      } else {
-        fResponse = fResult[0];
+
+        // If there is only one result returned, we unpack it and return it as it is, ditching the hosting array
+        if (fResponse.length === 1) {
+          fResponse = fResponse[0];
+        }
       }
 
       // Do various type re-mappings such as:

--- a/test/general/specs/StratoAddress.spec.ts
+++ b/test/general/specs/StratoAddress.spec.ts
@@ -30,11 +30,13 @@ describe("LiveAddress", () => {
   it("a bytes32 return value should not be interpreted as a LiveAddress", async () => {
     const liveContract = await load("keccak256");
     const hashResult = await liveContract.hash("asta banana");
+    const expectedHashResult = Buffer.from(
+      "26d381901a017b1d62fe70cbbe9ed6cf7f66db86f97a1c64f3571b777d7fe07e",
+      "hex"
+    );
 
     expect(hashResult).not.toBeInstanceOf(StratoAddress);
-    expect(hashResult).toEqual(
-      "0x26d381901a017b1d62fe70cbbe9ed6cf7f66db86f97a1c64f3571b777d7fe07e"
-    );
+    expect(expectedHashResult.compare(hashResult)).toEqual(0);
   });
 
   it("given bytes to LiveAddress constructor, it throws an error as it is not a solidity address", async () => {

--- a/test/solidity-by-example/specs/LiveContract.Solidity-by-Example.spec.ts
+++ b/test/solidity-by-example/specs/LiveContract.Solidity-by-Example.spec.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "@jest/globals";
 import { AccountId, Signer } from "@hashgraph/sdk";
+import { describe, expect, it } from "@jest/globals";
 import BigNumber from "bignumber.js";
 
 import {


### PR DESCRIPTION
... instead of their current hex-encoded strings.