### PR TITLE
Invalidating LiveEntity upon deletion

### DIFF
--- a/lib/ApiSession.ts
+++ b/lib/ApiSession.ts
@@ -64,7 +64,14 @@ export const enum TypeOfExecutionReturn {
   Result = "Result",
 }
 
-type ExecutionReturnTypes<T> = {
+export type AllowedExecutionReturnTypes<R> =
+  | ContractFunctionResult
+  | TransactionResponse
+  | R;
+export type ExecutionReturnTypes<
+  T extends AllowedExecutionReturnTypes<R>,
+  R = any
+> = {
   [TypeOfExecutionReturn.Receipt]: TransactionReceipt;
   [TypeOfExecutionReturn.Record]: TransactionRecord;
   [TypeOfExecutionReturn.Result]: T;
@@ -232,13 +239,11 @@ export class ApiSession implements SolidityAddressable {
     transaction: SessionExecutable<R>,
     returnType: T,
     getReceipt = false
-  ): Promise<
-    ExecutionReturnTypes<ContractFunctionResult | TransactionResponse | R>[T]
-  > {
+  ): Promise<ExecutionReturnTypes<AllowedExecutionReturnTypes<R>>[T]> {
     const isContractTransaction =
       transaction instanceof ContractCallQuery ||
       transaction instanceof ContractExecuteTransaction;
-    let executionResult: ContractFunctionResult | TransactionResponse | R;
+    let executionResult: AllowedExecutionReturnTypes<R>;
     let txReceipt: TransactionReceipt;
     let txRecord: TransactionRecord;
     const txResponse = await this.client.execute(transaction);

--- a/lib/live/BaseLiveEntityWithBalance.ts
+++ b/lib/live/BaseLiveEntityWithBalance.ts
@@ -17,10 +17,10 @@ export abstract class BaseLiveEntityWithBalance<
   I,
   P
 > extends LiveEntity<T, I, P> {
-  public getBalanceOfLiveEntity(): Promise<AccountBalance> {
+  public async getBalanceOfLiveEntity(): Promise<AccountBalance> {
     const queryPayload = this._getBalancePayload();
     const balanceQuery = new AccountBalanceQuery(queryPayload);
-    return this.session.execute(
+    return this.executeSanely(
       balanceQuery,
       TypeOfExecutionReturn.Result,
       false
@@ -37,7 +37,7 @@ export abstract class BaseLiveEntityWithBalance<
         amountToTransfer.negated()
       )
       .addHbarTransfer(this.id.toString(), amountToTransfer);
-    return this.executeAndReturnStatus(transferTransaction);
+    return this.sanelyExecuteAndGetStatus(transferTransaction);
   }
 
   public associateTokensWithLiveEntity(
@@ -46,7 +46,7 @@ export abstract class BaseLiveEntityWithBalance<
     const tokenAssociateTransaction = new TokenAssociateTransaction()
       .setAccountId(this.id.toString())
       .setTokenIds(tokens);
-    return this.executeAndReturnStatus(tokenAssociateTransaction);
+    return this.sanelyExecuteAndGetStatus(tokenAssociateTransaction);
   }
 
   protected override _getDeleteTransaction(args?: any): Transaction {

--- a/lib/live/LiveAccount.ts
+++ b/lib/live/LiveAccount.ts
@@ -33,7 +33,7 @@ export class LiveAccount extends BaseLiveEntityWithBalance<
 
   public getLiveEntityInfo(): Promise<AccountInfo> {
     const accountInfoQuery = new AccountInfoQuery().setAccountId(this.id);
-    return this.session.execute(
+    return this.executeSanely(
       accountInfoQuery,
       TypeOfExecutionReturn.Result,
       false

--- a/lib/live/LiveContract.ts
+++ b/lib/live/LiveContract.ts
@@ -167,7 +167,7 @@ export class LiveContract extends BaseLiveEntityWithBalance<
             isNonQuery && meta.onlyReceipt
               ? TypeOfExecutionReturn.Receipt
               : TypeOfExecutionReturn.Result;
-          const callResponse = await this.session.execute(
+          const callResponse = await this.executeSanely(
             request,
             executionResultType,
             meta.emitReceipt
@@ -490,7 +490,7 @@ export class LiveContract extends BaseLiveEntityWithBalance<
 
   public getLiveEntityInfo(): Promise<ContractInfo> {
     const contractInfoQuery = new ContractInfoQuery().setContractId(this.id);
-    return this.session.execute(
+    return this.executeSanely(
       contractInfoQuery,
       TypeOfExecutionReturn.Result,
       false

--- a/lib/live/LiveEntity.ts
+++ b/lib/live/LiveEntity.ts
@@ -1,5 +1,17 @@
-import { ApiSession, TypeOfExecutionReturn } from "../ApiSession";
-import { Status, Transaction } from "@hashgraph/sdk";
+import {
+  AllowedExecutionReturnTypes,
+  ApiSession,
+  ExecutionReturnTypes,
+  TypeOfExecutionReturn,
+} from "../ApiSession";
+import {
+  ContractFunctionResult,
+  Query,
+  Status,
+  Transaction,
+  TransactionResponse,
+} from "@hashgraph/sdk";
+import { ContractFunctionCall } from "./LiveContract";
 import { SolidityAddressable } from "../core/SolidityAddressable";
 
 export type HederaEntityId = {
@@ -7,11 +19,18 @@ export type HederaEntityId = {
 };
 
 /**
- * Common functionality exhibited by session-bounded, id-entifiable LiveEntity instances.
+ * Common functionality exhibited by session-bounded, identifiable LiveEntity instances.
  */
 export abstract class LiveEntity<T extends HederaEntityId, I, P>
   implements SolidityAddressable
 {
+  /**
+   * Sanity flag which, when true, signifies that the live-entity is still operating on the hashgraph (default) while,
+   * if false, the fact that no further network operations are possible on the underlying entity. This is usually the case
+   * following a self-delete operation.
+   */
+  private isSane = true;
+
   constructor(public readonly session: ApiSession, public readonly id: T) {}
 
   protected get log() {
@@ -25,26 +44,77 @@ export abstract class LiveEntity<T extends HederaEntityId, I, P>
     return this._equals(what);
   }
 
-  public deleteEntity(args?: any): Promise<Status> {
+  public async deleteEntity(args?: any): Promise<Status> {
     const transaction = this._getDeleteTransaction(args);
-    return this.executeAndReturnStatus(transaction);
+    const deleteTransactionResponse = await this.sanelyExecuteAndGetStatus(
+      transaction
+    );
+
+    this.isSane = false;
+    return deleteTransactionResponse;
   }
 
   public async updateEntity(args?: P): Promise<Status> {
     const transaction = await this._getUpdateTransaction(args);
-    return this.executeAndReturnStatus(transaction);
+    return this.sanelyExecuteAndGetStatus(transaction);
   }
 
   protected _equals<R>(what: R): boolean {
     return false;
   }
 
-  protected async executeAndReturnStatus(
+  /**
+   * Region of `executeSanely` overridable declarations. This should closely mimic the {@link ApiSession#execute} implementations.
+   */
+  protected async executeSanely<T extends TypeOfExecutionReturn>(
+    transaction: ContractFunctionCall,
+    returnType?: T,
+    getReceipt?: boolean
+  ): Promise<ExecutionReturnTypes<ContractFunctionResult>[T]>;
+  protected async executeSanely<T extends TypeOfExecutionReturn>(
+    transaction: Transaction,
+    returnType?: T,
+    getReceipt?: boolean
+  ): Promise<ExecutionReturnTypes<TransactionResponse>[T]>;
+  protected async executeSanely<T extends TypeOfExecutionReturn, R>(
+    transaction: Query<R>,
+    returnType?: T,
+    getReceipt?: boolean
+  ): Promise<ExecutionReturnTypes<R>[T]>;
+
+  /**
+   * Actual `sanity-execution`-able implementation. There should be only one `this.session.execute` call per {@link LiveEntity}.
+   */
+  protected async executeSanely<T extends TypeOfExecutionReturn, R>(
+    what: Query<R> | Transaction,
+    returnType: T,
+    getReceipt = false
+  ): Promise<ExecutionReturnTypes<AllowedExecutionReturnTypes<R>>[T]> {
+    this.sanityCheck((what as any).constructor.name);
+
+    return this.session.execute(what as any, returnType, getReceipt);
+  }
+
+  protected async sanelyExecuteAndGetStatus(
     transaction: Transaction
   ): Promise<Status> {
-    return this.session
-      .execute(transaction, TypeOfExecutionReturn.Receipt, false)
-      .then((receipt) => receipt.status);
+    const receipt = await this.executeSanely(
+      transaction,
+      TypeOfExecutionReturn.Receipt,
+      true
+    );
+
+    return receipt.status;
+  }
+
+  protected sanityCheck(opName = "") {
+    if (!this.isSane) {
+      throw new Error(
+        `Cannot perform this${
+          opName ? ` "${opName}"` : ""
+        } operation on an entity which is no longer sane (is no longer live on the network)`
+      );
+    }
   }
 
   public abstract getSolidityAddress(): string;

--- a/lib/live/LiveFile.ts
+++ b/lib/live/LiveFile.ts
@@ -28,7 +28,7 @@ export class LiveFile extends LiveEntity<FileId, FileInfo, FileFeatures> {
 
   public override getLiveEntityInfo(): Promise<FileInfo> {
     const fileInfoQuery = new FileInfoQuery({ fileId: this.id });
-    return this.session.execute(
+    return this.executeSanely(
       fileInfoQuery,
       TypeOfExecutionReturn.Result,
       false
@@ -55,7 +55,7 @@ export class LiveFile extends LiveEntity<FileId, FileInfo, FileFeatures> {
 
   public async getContents(): Promise<Uint8Array> {
     const fileContentsQuery = new FileContentsQuery({ fileId: this.id });
-    const queryResponse = await this.session.execute(
+    const queryResponse = await this.executeSanely(
       fileContentsQuery,
       TypeOfExecutionReturn.Result,
       false

--- a/lib/live/LiveToken.ts
+++ b/lib/live/LiveToken.ts
@@ -35,7 +35,7 @@ export class LiveToken extends LiveEntity<TokenId, TokenInfo, TokenFeatures> {
     const tokenUpdateTx = new TokenUpdateTransaction()
       .setTokenId(this.id)
       .setSupplyKey(key instanceof Key ? key : key.id);
-    await this.session.execute(
+    await this.executeSanely(
       tokenUpdateTx,
       TypeOfExecutionReturn.Receipt,
       true
@@ -44,7 +44,7 @@ export class LiveToken extends LiveEntity<TokenId, TokenInfo, TokenFeatures> {
 
   public async getLiveEntityInfo(): Promise<TokenInfo> {
     const tokenInfoQuery = new TokenInfoQuery().setTokenId(this.id);
-    return this.session.execute(
+    return this.executeSanely(
       tokenInfoQuery,
       TypeOfExecutionReturn.Result,
       false

--- a/lib/live/LiveTopic.ts
+++ b/lib/live/LiveTopic.ts
@@ -31,7 +31,7 @@ export class LiveTopic extends LiveEntity<TopicId, TopicInfo, TopicFeatures> {
 
   public override getLiveEntityInfo(): Promise<TopicInfo> {
     const topicInfoQuery = new TopicInfoQuery({ topicId: this.id });
-    return this.session.execute(
+    return this.executeSanely(
       topicInfoQuery,
       TypeOfExecutionReturn.Result,
       false
@@ -64,6 +64,6 @@ export class LiveTopic extends LiveEntity<TopicId, TopicInfo, TopicFeatures> {
       message,
       topicId: this.id,
     });
-    return this.executeAndReturnStatus(messageSubmitTransaction);
+    return this.sanelyExecuteAndGetStatus(messageSubmitTransaction);
   }
 }

--- a/test/solidity-by-example/specs/LiveContract.Solidity-by-Example.meta-args.spec.ts
+++ b/test/solidity-by-example/specs/LiveContract.Solidity-by-Example.meta-args.spec.ts
@@ -1,13 +1,14 @@
-import { describe, expect, it, jest } from "@jest/globals";
+import Long from "long";
+
 import {
   ContractCallQuery,
   ContractExecuteTransaction,
   Hbar,
   TransactionId,
 } from "@hashgraph/sdk";
+import { describe, expect, it, jest } from "@jest/globals";
 
 import { load as loadResource } from "../../utils";
-import Long from "long";
 
 function load(contractPath: string) {
   return loadResource(contractPath, "solidity-by-example");

--- a/test/solidity-by-example/specs/LiveContract.Solidity-by-Example.spec.ts
+++ b/test/solidity-by-example/specs/LiveContract.Solidity-by-Example.spec.ts
@@ -1,4 +1,4 @@
-import { AccountId, Signer } from "@hashgraph/sdk";
+import { AccountId, Signer, Status } from "@hashgraph/sdk";
 import { describe, expect, it } from "@jest/globals";
 import BigNumber from "bignumber.js";
 
@@ -121,6 +121,13 @@ describe("LiveContract.Solidity-by-Example", () => {
     const liveContract = await load("/hello_world");
 
     await expect(liveContract.greet()).resolves.toEqual("Hello World!");
+  });
+
+  it("uploading a contract then deleting it should not allow interacting with its live instance", async () => {
+    const liveContract = await load("/hello_world");
+
+    await expect(liveContract.deleteEntity()).resolves.toEqual(Status.Success);
+    await expect(liveContract.greet()).rejects.toThrow();
   });
 
   it("uploading a contract followed by a cold retrieval should be permitted through the deployed contract-Id and its original ABI", async () => {


### PR DESCRIPTION
... tests look green & offer a way to `executeSanely` a transaction from within a `LiveEntity`. 

![image](https://user-images.githubusercontent.com/210908/165529644-508c715f-7a51-4617-9a58-4571e30445dc.png)
