### PR TITLE
Aligned `package.json` export strategies with base `@hashgraph/sdk`

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -32,6 +32,7 @@ module.exports = {
             regenerator: true,
           },
         ],
+        ["babel-plugin-add-import-extension", { extension: "cjs" }],
       ],
     },
   },

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,29 +1,54 @@
 const sharedPresets = ["@babel/preset-typescript"];
+const sharedPlugins = [
+  "@babel/plugin-transform-runtime",
+  {
+    absoluteRuntime: false,
+    corejs: false,
+    helpers: true,
+    regenerator: true,
+  },
+];
 const shared = {
   ignore: ["test/**/*.spec.ts"],
   presets: sharedPresets,
-  plugins: [
-    [
-      "@babel/plugin-transform-runtime",
-      {
-        absoluteRuntime: false,
-        corejs: false,
-        helpers: true,
-        regenerator: true,
-      },
-    ],
-  ],
+  plugins: sharedPlugins,
 };
 
 module.exports = {
   env: {
-    esm: shared,
-    cjs: {
-      ...shared,
-      presets: [["@babel/env", { modules: "commonjs" }], ...sharedPresets],
+    esm: {
+      ignore: ["test/**/*.spec.ts"],
+      presets: ["@babel/preset-typescript"],
+      plugins: [
+        [
+          "@babel/plugin-transform-runtime",
+          {
+            absoluteRuntime: false,
+            corejs: false,
+            helpers: true,
+            regenerator: true,
+          },
+        ],
+        ["babel-plugin-add-import-extension", { extension: "mjs" }],
+      ],
     },
-    test: {
-      presets: [["@babel/env"], ...sharedPresets],
+    cjs: {
+      ignore: ["test/**/*.spec.ts"],
+      presets: [
+        ["@babel/env", { modules: "commonjs" }],
+        "@babel/preset-typescript",
+      ],
+      plugins: [
+        [
+          "@babel/plugin-transform-runtime",
+          {
+            absoluteRuntime: false,
+            corejs: false,
+            helpers: true,
+            regenerator: true,
+          },
+        ],
+      ],
     },
   },
 };

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,19 +1,3 @@
-const sharedPresets = ["@babel/preset-typescript"];
-const sharedPlugins = [
-  "@babel/plugin-transform-runtime",
-  {
-    absoluteRuntime: false,
-    corejs: false,
-    helpers: true,
-    regenerator: true,
-  },
-];
-const shared = {
-  ignore: ["test/**/*.spec.ts"],
-  presets: sharedPresets,
-  plugins: sharedPlugins,
-};
-
 module.exports = {
   env: {
     esm: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@buidlerlabs/hedera-strato-js",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@buidlerlabs/hedera-strato-js",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/abi": "^5.5.0",
@@ -26,6 +26,7 @@
         "@typescript-eslint/eslint-plugin": "^5.11.0",
         "@typescript-eslint/parser": "^5.11.0",
         "axios": "^0.26.0",
+        "babel-plugin-add-import-extension": "^1.6.0",
         "core-js": "^3.20.3",
         "elliptic": "^6.5.4",
         "eslint": "^8.8.0",
@@ -3868,6 +3869,18 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-add-import-extension": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-import-extension/-/babel-plugin-add-import-extension-1.6.0.tgz",
+      "integrity": "sha512-JVSQPMzNzN/S4wPRoKQ7+u8PlkV//BPUMnfWVbr63zcE+6yHdU2Mblz10Vf7qe+6Rmu4svF5jG7JxdcPi9VvKg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0"
       }
     },
     "node_modules/babel-plugin-dynamic-import-node": {
@@ -13130,6 +13143,15 @@
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "slash": "^3.0.0"
+      }
+    },
+    "babel-plugin-add-import-extension": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-import-extension/-/babel-plugin-add-import-extension-1.6.0.tgz",
+      "integrity": "sha512-JVSQPMzNzN/S4wPRoKQ7+u8PlkV//BPUMnfWVbr63zcE+6yHdU2Mblz10Vf7qe+6Rmu4svF5jG7JxdcPi9VvKg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "babel-plugin-dynamic-import-node": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   },
   "exports": {
     ".": {
-      "node": "./lib.cjs/index.js",
-      "default": "./lib.esm/index.js"
+      "require": "./lib.cjs/index.cjs",
+      "import": "./lib.esm/index.mjs"
     }
   },
   "files": [
@@ -15,13 +15,13 @@
     "lib.esm",
     "types"
   ],
-  "main": "./lib.cjs/index.js",
-  "module": "./lib.esm/index.js",
+  "main": "./lib.cjs/index.cjs",
+  "module": "./lib.esm/index.mjs",
   "name": "@buidlerlabs/hedera-strato-js",
   "scripts": {
     "build:4-publish": "run-s build:cjs build:esm build:declarations",
-    "build:cjs": "babel --env-name cjs lib --extensions .ts --out-dir lib.cjs --source-maps",
-    "build:esm": "babel --env-name esm lib --extensions .ts --out-dir lib.esm --source-maps",
+    "build:cjs": "babel --env-name cjs lib --extensions .ts --out-dir lib.cjs --source-maps --out-file-extension .cjs",
+    "build:esm": "babel --env-name esm lib --extensions .ts --out-dir lib.esm --source-maps --out-file-extension .mjs",
     "build:declarations": "tsc",
     "clean": "run-s clean:cjs clean:esm clean:declarations",
     "clean:cjs": "rm -fr lib.cjs",
@@ -60,6 +60,7 @@
     "@typescript-eslint/eslint-plugin": "^5.11.0",
     "@typescript-eslint/parser": "^5.11.0",
     "axios": "^0.26.0",
+    "babel-plugin-add-import-extension": "^1.6.0",
     "core-js": "^3.20.3",
     "elliptic": "^6.5.4",
     "eslint": "^8.8.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "name": "@buidlerlabs/hedera-strato-js",
   "scripts": {
     "build:4-publish": "run-s build:cjs build:esm build:declarations",
-    "build:cjs": "babel --env-name cjs lib --extensions .ts --out-dir lib.cjs --source-maps --out-file-extension .cjs",
+    "build:cjs": "babel --env-name cjs lib --extensions .ts --out-dir lib.cjs --out-file-extension .cjs",
     "build:esm": "babel --env-name esm lib --extensions .ts --out-dir lib.esm --source-maps --out-file-extension .mjs",
     "build:declarations": "tsc",
     "clean": "run-s clean:cjs clean:esm clean:declarations",


### PR DESCRIPTION
We need to test these in CommonJS scenarios (nodejs with `require`) before merging.

... tests look green.