### PR TITLE
Fixed `..` relative path imports for `Contract.XFrom({ path })` scenarios

### DIFF
--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -14,6 +14,7 @@ hashgraph
 Hbar
 hbars
 Hederas
+ipfs
 localised
 polies
 previewnet

--- a/lib/compiler/SolidityCompiler.ts
+++ b/lib/compiler/SolidityCompiler.ts
@@ -39,27 +39,28 @@ export class SolidityCompiler {
     const basePath = sdkPath.resolve(
       process.env.HEDERAS_CONTRACTS_RELATIVE_PATH || "contracts"
     );
+    const absoluteSourcePath =
+      path && sdkPath.isAbsolute(path)
+        ? path
+        : sdkPath.join(basePath, path || "");
     const content = code
-      ? code
-      : fs.readFileSync(
-          sdkPath.isAbsolute(path) ? path : sdkPath.join(basePath, path),
-          "utf8"
-        );
+      ? SolidityCompiler.sanitize(code)
+      : SolidityCompiler.getSource(absoluteSourcePath);
     // Note: Further options and info is available
     //       here https://docs.soliditylang.org/en/v0.8.10/using-the-compiler.html#input-description and
     //       here https://docs.soliditylang.org/en/v0.8.10/using-the-compiler.html#compiler-input-and-output-json-description
     const solInput = {
       language: "Solidity",
       settings: {
-        // FIXME: Issue #91: Make SolidityCompiler execution configurable
-        optimizer: {
-          enabled: true,
-          runs: 200,
-        },
         metadata: {
           // disabling metadata hash embedding to make the bytecode generation predictable at test-time
           // see https://docs.soliditylang.org/en/latest/metadata.html#encoding-of-the-metadata-hash-in-the-bytecode
           bytecodeHash: process.env.NODE_ENV === "test" ? "none" : "ipfs",
+        },
+        // FIXME: Issue #91: Make SolidityCompiler execution configurable
+        optimizer: {
+          enabled: true,
+          runs: 200,
         },
         outputSelection: {
           "*": {
@@ -80,7 +81,7 @@ export class SolidityCompiler {
         ? process.env.HEDERAS_CONTRACTS_INCLUDED_PREFIXES.split(/\s*,\s*/)
         : []),
     ];
-    const importsResolver = (sourcePath) => {
+    const importsResolver = (sourcePath: string) => {
       for (const prefix of importPrefixes) {
         let resolvedSourcePath;
 
@@ -96,10 +97,10 @@ export class SolidityCompiler {
         if (fs.existsSync(resolvedSourcePath)) {
           try {
             return {
-              contents: fs.readFileSync(resolvedSourcePath).toString("utf8"),
+              contents: SolidityCompiler.getSource(resolvedSourcePath),
             };
           } catch (e) {
-            return { error: "Error reading " + resolvedSourcePath + ": " + e };
+            return { error: `Error reading '${resolvedSourcePath}: ${e}` };
           }
         }
       }
@@ -118,5 +119,46 @@ export class SolidityCompiler {
       VIRTUAL_SOURCE_CONTRACT_FILE_NAME,
       jCompileResult
     );
+  }
+
+  /**
+   * Given the path of a solidity file, reads and returns its source code following any necessary preprocessing.
+   *
+   * Note: This provides fix for #114 (https://github.com/buidler-labs/hedera-strato-js/issues/114)
+   *       We need to replace all relative imports (. and .. alike) otherwise the VFS could load the same identifier into multiple references which would end up
+   *       erroring out with "Identifier already declared." error messages.
+   *
+   * @param fullSolPath - The absolute .sol path to be resolved
+   * @returns the loaded source content following any preprocessing
+   */
+  private static getSource(fullSolPath: string): string {
+    const solFolderPath = sdkPath.dirname(fullSolPath);
+    let fSource = fs.readFileSync(fullSolPath, "utf-8");
+    const importRegex = /[ ]*import\s*[\\]?['"]([\\.]?\.\/[^\\'"]+)[\\]?['"];/g;
+    const importMatches = fSource.match(importRegex) || [];
+
+    for (const match of importMatches) {
+      const importedEntity = importRegex.exec(fSource);
+      const resolvedImportFilePath = sdkPath.join(
+        solFolderPath,
+        importedEntity[1]
+      );
+
+      // TODO: log `[${fullSolPath}] Replacing '${importedEntity[1]}' with '${resolvedImportFilePath}'`
+      fSource = fSource.replace(match, `import '${resolvedImportFilePath}';`);
+    }
+    return fSource;
+  }
+
+  private static sanitize(rootCode: string): string {
+    const dotDotRelativeImportRegex =
+      /[ ]*import\s*[\\]?['"](\.\.\/[^\\'"]+)[\\]?['"];/g;
+
+    if (dotDotRelativeImportRegex.test(rootCode)) {
+      throw new Error(
+        "Compiling root-code with double relative import component (..) is not yet supported and will be implemented in #117."
+      );
+    }
+    return rootCode;
   }
 }

--- a/lib/errors/CompileIssues.ts
+++ b/lib/errors/CompileIssues.ts
@@ -18,7 +18,7 @@ export class CompileIssues extends Error {
   static _listOfSimpleIssueMessagesFor(rawIssues) {
     return rawIssues.map(
       (rIssue) =>
-        `[ ${rIssue.sourceLocation.start}:${rIssue.sourceLocation.end} ] ${rIssue.message}`
+        `[ ${rIssue.sourceLocation.start}:${rIssue.sourceLocation.end} ] ${rIssue.formattedMessage}`
     );
   }
 

--- a/test/hscs/specs/LiveContract.NFTShop.spec.ts
+++ b/test/hscs/specs/LiveContract.NFTShop.spec.ts
@@ -6,11 +6,6 @@ import {
 } from "@hashgraph/sdk";
 import { describe, expect, it } from "@jest/globals";
 
-import {
-  ResourceReadOptions,
-  getTokenToTest,
-  read as readResource,
-} from "../../utils";
 import { Account } from "../../../lib/static/create/Account";
 import { ApiSession } from "../../../lib/ApiSession";
 import { Contract } from "../../../lib/static/upload/Contract";
@@ -18,9 +13,10 @@ import { GasFees } from "../../constants";
 import { LiveAccountWithPrivateKey } from "../../../lib/live/LiveAccount";
 import { StratoContractArgumentsEncoder } from "../../../lib/core/StratoContractArgumentsEncoder";
 import { TokenTypes } from "../../../lib/static/create/Token";
+import { getTokenToTest } from "../../utils";
 
-function read(what: ResourceReadOptions) {
-  return readResource({ relativeTo: "hscs", ...what });
+function getContractPath(fileName: string) {
+  return `hscs/contracts/${fileName}.sol`;
 }
 
 describe("LiveContract.NFTShop", () => {
@@ -34,8 +30,8 @@ describe("LiveContract.NFTShop", () => {
       maxAutomaticTokenAssociations: 1,
     });
     const contract = await Contract.newFrom({
-      code: read({ contract: "NFTShop" }),
       ignoreWarnings: true,
+      path: getContractPath("NFTShop"),
     });
     const client = session.network
       .getClient()
@@ -116,7 +112,7 @@ describe("LiveContract.NFTShop", () => {
       false
     );
     const contract = await Contract.newFrom({
-      code: read({ contract: "NFTShop" }),
+      path: getContractPath("NFTShop"),
     });
 
     const { session } = await ApiSession.default();

--- a/test/hscs/specs/LiveContract.Strato.spec.ts
+++ b/test/hscs/specs/LiveContract.Strato.spec.ts
@@ -1,26 +1,22 @@
 import { describe, expect, it } from "@jest/globals";
 import { Hbar } from "@hashgraph/sdk";
 
-import {
-  ResourceReadOptions,
-  getTokenToTest,
-  read as readResource,
-} from "../../utils";
 import { Account } from "../../../lib/static/create/Account";
 import { ApiSession } from "../../../lib/ApiSession";
 import { Contract } from "../../../lib/static/upload/Contract";
 import { GasFees } from "../../constants";
 import { TokenTypes } from "../../../lib/static/create/Token";
+import { getTokenToTest } from "../../utils";
 
-function read(what: ResourceReadOptions) {
-  return readResource({ relativeTo: "hscs", ...what });
+function getContractPath(fileName: string) {
+  return `hscs/contracts/${fileName}.sol`;
 }
 
 describe("LiveContract.Strato", () => {
   it("given a fungible, live, token, burning over a precompiled contract-service bridge should be permitted", async () => {
     const contract = await Contract.newFrom({
-      code: read({ contract: "HelloWorldBurn" }),
       ignoreWarnings: true,
+      path: getContractPath("HelloWorldBurn"),
     });
     const token = getTokenToTest();
 
@@ -44,11 +40,11 @@ describe("LiveContract.Strato", () => {
   });
 
   it("given a fungible, live, token, associating it to a live-contract should allow the contract to control the supply and transfer to associated accounts", async () => {
-    const token = getTokenToTest({ keys: { kyc: null } });
+    const token = getTokenToTest({}, TokenTypes.FungibleCommon, false);
     const account = new Account({ maxAutomaticTokenAssociations: 1 });
     const contract = await Contract.newFrom({
-      code: read({ contract: "MintTransHTS" }),
       ignoreWarnings: true,
+      path: "hscs/contracts/MintTransHTS.sol",
     });
 
     // Make everything live
@@ -89,8 +85,8 @@ describe("LiveContract.Strato", () => {
       maxAutomaticTokenAssociations: 1,
     });
     const contract = await Contract.newFrom({
-      code: read({ contract: "MintTransHTS" }),
       ignoreWarnings: true,
+      path: getContractPath("MintTransHTS"),
     });
 
     // Make everything live
@@ -128,8 +124,8 @@ describe("LiveContract.Strato", () => {
   it("given a non-fungible, live, token, a contract would make use of the HTS to mint multiple and make the NFT transfers to associated accounts", async () => {
     const account = new Account({ maxAutomaticTokenAssociations: 1 });
     const contract = await Contract.newFrom({
-      code: read({ contract: "MintTransHTS" }),
       ignoreWarnings: true,
+      path: getContractPath("MintTransHTS"),
     });
 
     // Make everything live

--- a/test/issues/contracts/issue-114/B.sol
+++ b/test/issues/contracts/issue-114/B.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.9;
+
+abstract contract B {}

--- a/test/issues/contracts/issue-114/C.sol
+++ b/test/issues/contracts/issue-114/C.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.9;
+
+import "./inner/A.sol";
+
+abstract contract C is A {}

--- a/test/issues/contracts/issue-114/inner/A.sol
+++ b/test/issues/contracts/issue-114/inner/A.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.9;
+
+import "../B.sol";
+
+abstract contract A is B {}

--- a/test/issues/specs/114-sol-import-resolution.spec.ts
+++ b/test/issues/specs/114-sol-import-resolution.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { Contract } from "../../../lib/static/upload/Contract";
+
+describe("Issue #114 > Solidity Contract Import Resolution Fix for loading from paths", () => {
+  it("import '../B' within A should resolve to a valid A contract resolving B as its dependency", async () => {
+    await expect(
+      Contract.newFrom({
+        ignoreWarnings: true,
+        path: "issues/contracts/issue-114/inner/A.sol",
+      })
+    ).resolves.not.toThrow();
+  });
+
+  it("import './inner/A' from C should resolve to a valid C contract resolving A and then B as its dependency", async () => {
+    await expect(
+      Contract.newFrom({
+        ignoreWarnings: true,
+        path: "issues/contracts/issue-114/C.sol",
+      })
+    ).resolves.not.toThrow();
+  });
+
+  it("importing '..' from code should not be supported until #117 gets resolved", async () => {
+    await expect(
+      Contract.newFrom({
+        code: "import '../B.sol'; contract A {}",
+        ignoreWarnings: true,
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/test/taskbar/specs/LiveContract.TaskBar.spec.ts
+++ b/test/taskbar/specs/LiveContract.TaskBar.spec.ts
@@ -12,6 +12,10 @@ function read(what: ResourceReadOptions) {
   return readResource({ relativeTo: "taskbar", ...what });
 }
 
+function getContractPath(fileName: string) {
+  return `taskbar/contracts/${fileName}.sol`;
+}
+
 describe("LiveContract.TaskBar", () => {
   it("given the taskbar use-case contracts, initializing a task should allow for getting it back later on", async () => {
     const maxNrOfTasksPerRegistry = new BigNumber(2);
@@ -19,11 +23,11 @@ describe("LiveContract.TaskBar", () => {
 
     const { session } = await ApiSession.default();
     const taskRegistryContract = await Contract.newFrom({
-      code: read({ contract: "TaskRegistry" }),
       ignoreWarnings: true,
+      path: getContractPath("TaskRegistry"),
     });
     const cappedRegistryHelperContract = await Contract.newFrom({
-      code: read({ contract: "CappedRegistryHelper" }),
+      path: getContractPath("CappedRegistryHelper"),
     });
     const cappedRegistryLiveContract = await session.upload(
       cappedRegistryHelperContract,


### PR DESCRIPTION
`npm run test:jsdom`
![image](https://user-images.githubusercontent.com/210908/196661140-42f3ef4b-e19c-45ba-822a-6d1b3be74183.png)

`npm run test:node`
![image](https://user-images.githubusercontent.com/210908/196661042-babb5f19-89f1-4373-a0c3-c31c0892974e.png)
